### PR TITLE
Pin setuptools_scm[toml] > 3.4

### DIFF
--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,5 +1,5 @@
+tenacity
 setuptools>=42
 # NOTE: The typing-extensions could not be installed without this requirement to be specified.
 flit-core>=3
-# NOTE: pbr 6.1.1 introduced a dependency on setuptools>=64, which is not available in the build environment constraints.
-pbr==6.1.0
+setuptools_scm[toml]>=3.4

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,4 +1,5 @@
-Markupsafe<2.0.0  # for xenial support
-tenacity<5.0.4 # workaround for LP#2031582
 setuptools>=42
+# NOTE: The typing-extensions could not be installed without this requirement to be specified.
 flit-core>=3
+# NOTE: pbr 6.1.1 introduced a dependency on setuptools>=64, which is not available in the build environment constraints.
+pbr==6.1.0


### PR DESCRIPTION
Some package (likely setuptools-59.6.0 or flit_core-3.10.1) now requires setuptools_scm[toml] >= 3.4.
Since setuptools_scm[toml]>=3.4 isn't in the wheelhouse, the installation started to fail.